### PR TITLE
AgriNet Ops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,4 +164,12 @@ cython_debug/
 nirscene0/
 model.png 
 logs/
+
+# Checkpoint files and weights from training
 training_checkpoints/
+*.pb
+discriminator_*/
+generator_*/
+discriminator_weights_*
+generator_weights_*
+checkpoint

--- a/agrinet/train.py
+++ b/agrinet/train.py
@@ -116,7 +116,19 @@ def main(args):
     filetime = time.strftime("%d%m%y_%H%M")
     tf.saved_model.save(generator, "./generator_{}".format(filetime))
     tf.saved_model.save(discriminator, "./discriminator_{}".format(filetime))
-    logger.info("Model(s) saved")
+
+    try:
+        generator.save_weights("./generator_weights_{}".format(filetime))
+        discriminator.save_weights("./discriminator_weights_{}".format(filetime))
+
+    except Exception as e:
+        logger.error("Error while saving weights : {}".format(e))
+
+    logger.debug(
+        "Model and weights saved at {} and {} respectively".format(
+            "./generator_{} ".format(filetime), " ./discriminator_{}".format(filetime)
+        )
+    )
 
 
 def parse_args():

--- a/agrinet/train.py
+++ b/agrinet/train.py
@@ -1,0 +1,70 @@
+import argparse
+
+import tensorflow as tf
+from utils.LogManager import LogManager
+from utils.DataLoader import load_image_train, load_image_test
+
+BUFFER_SIZE = 400
+
+
+def main(args):
+    logger = LogManager.get_logger("AGRINET TRAIN")
+
+    # Gathering training and testing images
+    logger.info("Building data pipeline...")
+
+    train_dataset = tf.data.Dataset.list_files(args.data_dir + "/train/*." + args.ext)
+    train_dataset = train_dataset.map(
+        load_image_train, num_parallel_calls=tf.data.AUTOTUNE
+    )
+    train_dataset = train_dataset.shuffle(BUFFER_SIZE)
+    train_dataset = train_dataset.batch(args.batch_size)
+    logger.debug("Train dataset contains {} images".format(len(train_dataset)))
+
+    test_dataset = tf.data.Dataset.list_files(args.data_dir + "/test/*." + args.ext)
+    test_dataset = test_dataset.map(load_image_test)
+    test_dataset = test_dataset.batch(args.batch_size)
+    logger.debug("Test dataset contains {} images".format(len(test_dataset)))
+
+    logger.info("Building model...")
+
+    logger.info("Starting training...")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--data_dir",
+        type=str,
+        default="data",
+        help="Path to data directory",
+        required=True,
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=32,
+        help="Batch size for training",
+        required=True,
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=100,
+        help="Number of epochs to train",
+        required=True,
+    )
+    parser.add_argument(
+        "--lr", type=float, default=1e-3, help="Learning rate for training"
+    )
+    parser.add_argument(
+        "--ext", type=str, default="jpg", help="Extension of the images"
+    )
+    parser.add_argument("--seed", type=int, default=10, help="Random seed for training")
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)

--- a/agrinet/utils/DataLoader.py
+++ b/agrinet/utils/DataLoader.py
@@ -1,0 +1,76 @@
+import tensorflow as tf
+
+IMG_WIDTH = 256
+IMG_HEIGHT = 256
+
+
+def load(image_file):
+    image = tf.io.read_file(image_file)
+    image = tf.io.decode_jpeg(image)
+
+    w = tf.shape(image)[1]
+    w = w // 2
+    input_image = image[:, w:, :]
+    real_image = image[:, :w, :]
+
+    input_image = tf.cast(input_image, tf.float32)
+    real_image = tf.cast(real_image, tf.float32)
+
+    input_image = tf.image.resize(input_image, [256, 256])
+    real_image = tf.image.resize(real_image, [256, 256])
+
+    return real_image, input_image
+
+
+def resize(input_image, real_image, height, width):
+    input_image = tf.image.resize(
+        input_image, [height, width], method=tf.image.ResizeMethod.NEAREST_NEIGHBOR
+    )
+    real_image = tf.image.resize(
+        real_image, [height, width], method=tf.image.ResizeMethod.NEAREST_NEIGHBOR
+    )
+
+    return input_image, real_image
+
+
+def random_crop(input_image, real_image):
+    stacked_image = tf.stack([input_image, real_image], axis=0)
+    cropped_image = tf.image.random_crop(
+        stacked_image, size=[2, IMG_HEIGHT, IMG_WIDTH, 3]
+    )
+
+    return cropped_image[0], cropped_image[1]
+
+
+# Normalizing the images to [-1, 1]
+def normalize(input_image, real_image):
+    input_image = (input_image / 127.5) - 1
+    real_image = (real_image / 127.5) - 1
+
+    return input_image, real_image
+
+
+@tf.function()
+def random_jitter(input_image, real_image):
+    if tf.random.uniform(()) > 0.5:
+        # Random mirroring
+        input_image = tf.image.flip_left_right(input_image)
+        real_image = tf.image.flip_left_right(real_image)
+
+    return input_image, real_image
+
+
+def load_image_train(image_file):
+    input_image, real_image = load(image_file)
+    input_image, real_image = random_jitter(input_image, real_image)
+    input_image, real_image = normalize(input_image, real_image)
+
+    return input_image, real_image
+
+
+def load_image_test(image_file):
+    input_image, real_image = load(image_file)
+    input_image, real_image = resize(input_image, real_image, IMG_HEIGHT, IMG_WIDTH)
+    input_image, real_image = normalize(input_image, real_image)
+
+    return input_image, real_image

--- a/agrinet/utils/LogManager.py
+++ b/agrinet/utils/LogManager.py
@@ -19,7 +19,7 @@ class LogManager:
             self.log = logging.getLogger(name if name else __name__)
             self.log.setLevel(logging.DEBUG)
             formatter = colorlog.ColoredFormatter(
-                "%(asctime)s [%(name)s] %(log_color)s%(levelname)s%(reset)s %(message)s",
+                "%(asctime)s [%(name)s] %(log_color)s:: %(levelname)s ::%(reset)s %(message)s",
                 log_colors={
                     "DEBUG": "cyan",
                     "INFO": "green",

--- a/agrinet/utils/LogManager.py
+++ b/agrinet/utils/LogManager.py
@@ -17,9 +17,9 @@ class LogManager:
         else:
             LogManager.__instance = self
             self.log = logging.getLogger(name if name else __name__)
-            self.log.setLevel(logging.INFO)
+            self.log.setLevel(logging.DEBUG)
             formatter = colorlog.ColoredFormatter(
-                "%(asctime)s [%(name)s] %(log_color)s%(levelname)s%(reset)s - %(message)s",
+                "%(asctime)s [%(name)s] %(log_color)s%(levelname)s%(reset)s %(message)s",
                 log_colors={
                     "DEBUG": "cyan",
                     "INFO": "green",

--- a/agrinet/utils/LogManager.py
+++ b/agrinet/utils/LogManager.py
@@ -1,0 +1,36 @@
+import logging
+import colorlog
+
+
+class LogManager:
+    __instance = None
+
+    @staticmethod
+    def get_logger(name=None):
+        if LogManager.__instance is None:
+            LogManager(name)
+        return LogManager.__instance.log
+
+    def __init__(self, name=None):
+        if LogManager.__instance is not None:
+            raise Exception("This class is a singleton!")
+        else:
+            LogManager.__instance = self
+            self.log = logging.getLogger(name if name else __name__)
+            self.log.setLevel(logging.INFO)
+            formatter = colorlog.ColoredFormatter(
+                "%(asctime)s [%(name)s] %(log_color)s%(levelname)s%(reset)s - %(message)s",
+                log_colors={
+                    "DEBUG": "cyan",
+                    "INFO": "green",
+                    "WARNING": "yellow",
+                    "ERROR": "red",
+                    "CRITICAL": "red,bg_white",
+                },
+            )
+            handler = logging.StreamHandler()
+            handler.setFormatter(formatter)
+            self.log.addHandler(handler)
+
+    def set_level(self, level):
+        self.log.setLevel(level)

--- a/agrinet/utils/Model.py
+++ b/agrinet/utils/Model.py
@@ -1,0 +1,168 @@
+import tensorflow as tf
+
+OUTPUT_CHANNELS = 3
+LAMBDA = 100
+
+generator_optimizer = tf.keras.optimizers.Adam(2e-4, beta_1=0.5)
+discriminator_optimizer = tf.keras.optimizers.Adam(2e-4, beta_1=0.5)
+
+
+def downsample(filters, size, apply_batchnorm=True):
+    initializer = tf.random_normal_initializer(0.0, 0.02)
+
+    result = tf.keras.Sequential()
+    result.add(
+        tf.keras.layers.Conv2D(
+            filters,
+            size,
+            strides=2,
+            padding="same",
+            kernel_initializer=initializer,
+            use_bias=False,
+        )
+    )
+
+    if apply_batchnorm:
+        result.add(tf.keras.layers.BatchNormalization())
+
+    result.add(tf.keras.layers.LeakyReLU())
+
+    return result
+
+
+def upsample(filters, size, apply_dropout=False):
+    initializer = tf.random_normal_initializer(0.0, 0.02)
+
+    result = tf.keras.Sequential()
+    result.add(
+        tf.keras.layers.Conv2DTranspose(
+            filters,
+            size,
+            strides=2,
+            padding="same",
+            kernel_initializer=initializer,
+            use_bias=False,
+        )
+    )
+
+    result.add(tf.keras.layers.BatchNormalization())
+
+    if apply_dropout:
+        result.add(tf.keras.layers.Dropout(0.5))
+
+    result.add(tf.keras.layers.ReLU())
+
+    return result
+
+
+def Generator():
+    inputs = tf.keras.layers.Input(shape=[256, 256, 3])
+
+    down_stack = [
+        downsample(64, 4, apply_batchnorm=False),  # (batch_size, 128, 128, 64)
+        downsample(128, 4),  # (batch_size, 64, 64, 128)
+        downsample(256, 4),  # (batch_size, 32, 32, 256)
+        downsample(512, 4),  # (batch_size, 16, 16, 512)
+        downsample(512, 4),  # (batch_size, 8, 8, 512)
+        downsample(512, 4),  # (batch_size, 4, 4, 512)
+        downsample(512, 4),  # (batch_size, 2, 2, 512)
+        downsample(512, 4),  # (batch_size, 1, 1, 512)
+    ]
+
+    up_stack = [
+        upsample(512, 4, apply_dropout=True),  # (batch_size, 2, 2, 1024)
+        upsample(512, 4, apply_dropout=True),  # (batch_size, 4, 4, 1024)
+        upsample(512, 4, apply_dropout=True),  # (batch_size, 8, 8, 1024)
+        upsample(512, 4),  # (batch_size, 16, 16, 1024)
+        upsample(256, 4),  # (batch_size, 32, 32, 512)
+        upsample(128, 4),  # (batch_size, 64, 64, 256)
+        upsample(64, 4),  # (batch_size, 128, 128, 128)
+    ]
+
+    initializer = tf.random_normal_initializer(0.0, 0.02)
+    last = tf.keras.layers.Conv2DTranspose(
+        OUTPUT_CHANNELS,
+        4,
+        strides=2,
+        padding="same",
+        kernel_initializer=initializer,
+        activation="tanh",
+    )  # (batch_size, 256, 256, 3)
+
+    x = inputs
+
+    # Downsampling through the model
+    skips = []
+    for down in down_stack:
+        x = down(x)
+        skips.append(x)
+
+    skips = reversed(skips[:-1])
+
+    # Upsampling and establishing the skip connections
+    for up, skip in zip(up_stack, skips):
+        x = up(x)
+        x = tf.keras.layers.Concatenate()([x, skip])
+
+    x = last(x)
+
+    return tf.keras.Model(inputs=inputs, outputs=x)
+
+
+loss_object = tf.keras.losses.BinaryCrossentropy(from_logits=True)
+
+
+def generator_loss(disc_generated_output, gen_output, target):
+    gan_loss = loss_object(tf.ones_like(disc_generated_output), disc_generated_output)
+
+    # Mean absolute error
+    l1_loss = tf.reduce_mean(tf.abs(target - gen_output))
+
+    total_gen_loss = gan_loss + (LAMBDA * l1_loss)
+
+    return total_gen_loss, gan_loss, l1_loss
+
+
+def Discriminator():
+    initializer = tf.random_normal_initializer(0.0, 0.02)
+
+    inp = tf.keras.layers.Input(shape=[256, 256, 3], name="input_image")
+    tar = tf.keras.layers.Input(shape=[256, 256, 3], name="target_image")
+
+    x = tf.keras.layers.concatenate([inp, tar])  # (batch_size, 256, 256, channels*2)
+
+    down1 = downsample(64, 4, False)(x)  # (batch_size, 128, 128, 64)
+    down2 = downsample(128, 4)(down1)  # (batch_size, 64, 64, 128)
+    down3 = downsample(256, 4)(down2)  # (batch_size, 32, 32, 256)
+
+    zero_pad1 = tf.keras.layers.ZeroPadding2D()(down3)  # (batch_size, 34, 34, 256)
+    conv = tf.keras.layers.Conv2D(
+        512, 4, strides=1, kernel_initializer=initializer, use_bias=False
+    )(
+        zero_pad1
+    )  # (batch_size, 31, 31, 512)
+
+    batchnorm1 = tf.keras.layers.BatchNormalization()(conv)
+
+    leaky_relu = tf.keras.layers.LeakyReLU()(batchnorm1)
+
+    zero_pad2 = tf.keras.layers.ZeroPadding2D()(leaky_relu)  # (batch_size, 33, 33, 512)
+
+    last = tf.keras.layers.Conv2D(1, 4, strides=1, kernel_initializer=initializer)(
+        zero_pad2
+    )  # (batch_size, 30, 30, 1)
+
+    return tf.keras.Model(inputs=[inp, tar], outputs=last)
+
+
+def discriminator_loss(disc_real_output, disc_generated_output):
+    real_loss = loss_object(tf.ones_like(disc_real_output), disc_real_output)
+
+    generated_loss = loss_object(
+        tf.zeros_like(disc_generated_output), disc_generated_output
+    )
+
+    total_disc_loss = real_loss + generated_loss
+
+    return total_disc_loss
+

--- a/agrinet/utils/Visuals.py
+++ b/agrinet/utils/Visuals.py
@@ -1,0 +1,17 @@
+import matplotlib.pyplot as plt
+
+
+def generate_images(model, test_input, tar):
+    prediction = model(test_input, training=True)
+    plt.figure(figsize=(15, 15))
+
+    display_list = [test_input[0], tar[0], prediction[0]]
+    title = ["Input Image", "Ground Truth", "Predicted Image"]
+
+    for i in range(3):
+        plt.subplot(1, 3, i + 1)
+        plt.title(title[i])
+        # Getting the pixel values in the [0, 1] range to plot.
+        plt.imshow(display_list[i] * 0.5 + 0.5)
+        plt.axis("off")
+    plt.show()

--- a/environment.yml
+++ b/environment.yml
@@ -131,12 +131,19 @@ dependencies:
       - absl-py==2.0.0
       - aiohttp==3.9.1
       - aiosignal==1.3.1
+      - altair==5.2.0
       - astunparse==1.6.3
       - async-timeout==4.0.3
       - attrs==23.2.0
       - cachetools==5.3.2
+      - cloudpickle==3.0.0
+      - colorlog==6.8.0
       - contourpy==1.1.1
       - cycler==0.12.1
+      - dask==2023.5.0
+      - dask-jobqueue==0.8.2
+      - distributed==2023.5.0
+      - dominate==2.9.1
       - filelock==3.13.1
       - flatbuffers==23.5.26
       - fonttools==4.47.0
@@ -149,12 +156,19 @@ dependencies:
       - h5py==3.10.0
       - imageio==2.33.1
       - importlib-resources==6.1.1
+      - isort==5.13.2
+      - joblib==1.3.2
+      - jsonschema==4.21.0
+      - jsonschema-specifications==2023.12.1
       - keras==2.13.1
       - kiwisolver==1.4.5
+      - lazy-loader==0.3
       - libclang==16.0.6
+      - locket==1.0.0
       - markdown==3.5.1
       - matplotlib==3.7.4
       - mpmath==1.3.0
+      - msgpack==1.0.7
       - multidict==6.0.4
       - networkx==3.1
       - numpy==1.24.4
@@ -162,7 +176,11 @@ dependencies:
       - opencv-python==4.9.0.80
       - opt-einsum==3.3.0
       - pandas==2.0.3
+      - partd==1.4.1
+      - patsy==0.5.6
       - pillow==10.2.0
+      - pkgutil-resolve-name==1.3.10
+      - plantcv==4.0.1
       - protobuf==4.25.1
       - py-cpuinfo==9.0.0
       - pyasn1==0.5.1
@@ -170,11 +188,19 @@ dependencies:
       - pydot==2.0.0
       - pyparsing==3.1.1
       - python-graphviz==0.20.1
+      - pywavelets==1.4.1
+      - referencing==0.32.1
       - requests-oauthlib==1.3.1
+      - rpds-py==0.17.1
       - rsa==4.9
+      - scikit-image==0.21.0
+      - scikit-learn==1.3.2
       - scipy==1.10.1
       - seaborn==0.13.1
+      - sortedcontainers==2.4.0
+      - statsmodels==0.14.1
       - sympy==1.12
+      - tblib==3.0.0
       - tensorboard==2.13.0
       - tensorboard-data-server==0.7.2
       - tensorflow==2.13.1
@@ -182,13 +208,19 @@ dependencies:
       - tensorflow-io-gcs-filesystem==0.34.0
       - termcolor==2.4.0
       - thop==0.1.1-2209072238
+      - threadpoolctl==3.2.0
+      - tifffile==2023.7.10
+      - toolz==0.12.0
       - torch==2.1.2
       - torchvision==0.16.2
       - typing-extensions==4.5.0
       - tzdata==2023.4
       - ultralytics==8.0.235
       - urllib3==2.1.0
+      - vl-convert-python==1.2.0
       - werkzeug==3.0.1
       - wrapt==1.16.0
+      - xarray==2023.1.0
       - yarl==1.9.4
+      - zict==3.0.0
 prefix: /Users/adambyrne/anaconda3/envs/ai-utils


### PR DESCRIPTION
### Goal: build tooling to allow for a formal v1

AgriNet has been made in a notebook. For further training and testing we need to move to a CLI based approach so we save time.

- `train.py` : Train a model with checkpoints and logging
- `test.py` : Run a model against test data for metrics
- `inference.py` : Run the model via CLI with code structured for (Class based use)

---
**Notes:** 
- It would be nice to switch to Pix2PixHD, once we have everything working nicely.
- We will leave cross-validation for now, til we have a few models trained.
- We need to document the use of the CLI so we will put the `-h` output into `agrinet/README.md` for reusability.
- Unit tests for functions.